### PR TITLE
Adds image tags to Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # compose
 DyCons server configuration and deployment
 
+## Table of Contents
+- [compose](#compose)
+  - [Table of Contents](#table-of-contents)
+  - [Setting up Keycloak for testing:](#setting-up-keycloak-for-testing)
+  - [Participant Portal + Participant IdP](#participant-portal--participant-idp)
+  - [Researcher Portal + Researcher IdP](#researcher-portal--researcher-idp)
+  - [REMS + Researcher IdP](#rems--researcher-idp)
+
 ## Setting up Keycloak for testing:
 
 Setup expects the following reposto be available on the development/test machine:
@@ -59,7 +67,7 @@ git clone https://github.com/CSCfi/rems.git ../rems
    1. Boot up the React frontend by running `docker-compose up rp-react`.
    2. Start by going to http://127.0.0.1:3004/.
    3. Click on the "Log In" button and you should be redirected to the Keycloak login screen.
-   4. Access the account using `varchar`/`varchar`. You'll be redirected back to the React frontend with the user's username, email and JWT token 
+   4. Access the account using `varchar`/`varchar`. You'll be redirected back to the React frontend with the user's username, email and JWT token
    displayed.
    5. ** For active development **
       1. Instead of step 1, run: `docker-compose run --rm --entrypoint sh --service-port rp-react`. This will log you into the application.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,7 @@ volumes:
 
 services:
   pp-keycloak:
+    image: dycons.pp-keycloak
     build:
       context: ${PARTICIPANT_PORTAL_KEYCLOAK_DIR}
     environment:
@@ -12,6 +13,7 @@ services:
     ports:
       - "8080:8080"
   pp-react:
+    image: dycons.pp-react
     build:
       context: ${PARTICIPANT_PORTAL_REACT_DIR}
     ports:
@@ -19,7 +21,10 @@ services:
     volumes:
       - ${PARTICIPANT_PORTAL_REACT_DIR}:/app
       - /app/node_modules
+    depends_on:
+      - pp-keycloak
   rems:
+    image: dycons.rems
     build:
       context: ${REMS_DIR}
       dockerfile: Dockerfile
@@ -41,6 +46,7 @@ services:
     ports:
       - "127.0.0.1:5432:5432"
   rp-keycloak:
+    image: dycons.rp-keycloak
     build:
       context: ${RESEARCHER_PORTAL_KEYCLOAK_DIR}
     environment:
@@ -49,6 +55,7 @@ services:
     ports:
       - "3002:8080"
   rp-react:
+    image: dycons.rp-react
     build:
       context: ${RESEARCHER_PORTAL_REACT_DIR}
     ports:


### PR DESCRIPTION
# This Pull Request:

Adds image tags using the `image` key in the docker-compose file. This helps us identify the images locally and helps with debugging. 