### PR TITLE
Updated Katsu service to use image stored in GitHub Container Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,18 @@ git clone https://github.com/CanDIG/candigv2_opa.git ../candigv2_opa
       3. Continue development on your machine - changes will be mapped to the volume inside the container and reflected at http://127.0.0.1:3002
 
 ## Researcher Portal + Researcher IdP + Katsu + REMS + OPA
-1. **Start up Researcher IdP, Katsu and OPA**:
-   1. Run `docker-compose up rp-keycloak katsu`.
-2. **Add Test Realm**:
+1. **Start up Researcher IdP**:
+   1. Run `docker-compose up rp-keycloak`.
+2. **Start up Katsu and OPA**:
+   1. Follow the steps [here](https://docs.github.com/en/packages/guides/pushing-and-pulling-docker-images#authenticating-to-github-container-registry) to authenticate to the GitHub Container Registry.
+   2. Run `docker-compose up katsu`.
+3. **Add Test Realm**:
    1. Navigate to http://127.0.0.1:3002/auth/admin.
    2. Login using the username and password: `admin` / `admin`.
    3. Add the test **Realm** by hovering over the "Master" label in the top left, and click "Add realm".
    4. Click "Select File" and choose the preconfigured realm at `../researcher-portal/keycloak/realms-export.json`. The name should be autofilled with `dycons-researcher-idp`.
    5. Click "Create" to finish.
-3. **Add Test Users**:
+4. **Add Test Users**:
    1. Navigate to the "Users" menu via the navbar on the left.
    2. Click "Add user" on the right side of the page.
    3. Set the username to `varchar` and click "Save".
@@ -76,22 +79,22 @@ git clone https://github.com/CanDIG/candigv2_opa.git ../candigv2_opa
    9. Copy the value in the `ID` field and assign this value to `REMS_OWNER_ID` in the `.env` file.
    10. On the next page, click the "Credentials" tab.
    11. Enter `owner` in both password fields, toggle `Temporary` *off*, and click "Set Password".
-4. **Expose Keycloak to REMS**:
+5. **Expose Keycloak to REMS**:
    1. Navigate to "Clients" via the navbar on the left.
    2. Under column "Client ID", select `rems-client`.
    3. Click the "Credentials" tab.
    4. Click `Regenerate Secret` and copy the secret generated.
    5. Open `services/rems/simple-config.edn` and modify the `:oidc-client-secret` key to use the secret generated.
-5. **Add Sample Katsu Data**:
+6. **Add Sample Katsu Data**:
    1. To add sample data to Katsu, run: `docker exec -it -w /app/chord_metadata_service/scripts katsu python ingest.py`.
-6. **Add Authorization Rules to OPA**:
+7. **Add Authorization Rules to OPA**:
    1. Run `./services/opa/opa_initialize.sh`.
-7. **Migrate and Seed REMS**:
+8. **Migrate and Seed REMS**:
    1. Run `./migrations/migrate.sh -s rems` to prepare the database and migrate the required tables.
    2. Run `docker-compose run --rm -e CMD="test-data" rems` to populate REMS with test data.
-8. **Start up REMS**:
+9. **Start up REMS**:
    1. Run `docker-compose up rems`.
-9. **Log In to REMS**:
+10. **Log In to REMS**:
    1. Navigate to http://127.0.0.1:3001.
    2. Click "Login".
    3. Login using the username and password: `owner` / `owner`.
@@ -107,9 +110,9 @@ git clone https://github.com/CanDIG/candigv2_opa.git ../candigv2_opa
    13. Navigate to the tab http://127.0.0.1:3002/auth/admin.
    14. Navigate to the "Sessions" menu via the navbar on the left.
    15. Click "Logout all" on the right side of the page.
-10. **Initialize REMS**:
+11. **Initialize REMS**:
    1. Run `./services/rems/rems_initialize.sh`.
-11. **Testing** - Now it's time to test our setup by using the bundled front end:
+12. **Testing** - Now it's time to test our setup by using the bundled front end:
    1. Boot up the React frontend by running `docker-compose up rp-react`.
    2. Start by going to http://127.0.0.1:3004/.
    3. Click on the "Log In" button and you should be redirected to the Keycloak login screen.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -105,7 +105,7 @@ services:
     volumes:
       - katsu-db-data:/var/lib/postgresql/data
   katsu:
-    image: samarth01/candig-katsu:latest
+    image: ghcr.io/candig/candig-katsu:latest
     container_name: katsu
     volumes:
       - ./services/katsu/katsu_entrypoint.sh:/app/katsu_entrypoint.sh


### PR DESCRIPTION
I updated the Katsu service to use the image stored in the CanDIG GitHub Container Registry.

## Changelog
Registration is now required to pull the image. Register by following the steps here: https://docs.github.com/en/packages/guides/pushing-and-pulling-docker-images#authenticating-to-github-container-registry