### PR TITLE
Removed env variable REMS_OWNER_ID and added env variable REMS_API_KEY

### DIFF
--- a/.default.env
+++ b/.default.env
@@ -13,10 +13,7 @@ REMS_POSTGRES_USER=rems
 REMS_POSTGRES_PASSWORD=remspassword
 REMS_CLIENT_ID=edf83af5-9964-427b-b70b-25d9a1bb5ff2
 
-# Environment variable REMS_OWNER_ID is used for a temporary workaround and should be removed once
-# REMS #2631 (https://github.com/CSCfi/rems/issues/2631) is completed
-# The default value ${REMS_OWNER_ID} is a placeholder; must be replaced.
-REMS_OWNER_ID=${REMS_OWNER_ID}
+REMS_API_KEY=${REMS_API_KEY}
 
 RESEARCHER_PORTAL_REACT_DIR=../researcher-portal/researcher-portal-react
 RP_KEYCLOAK_USER=admin

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -110,7 +110,7 @@ services:
       - ${RESEARCHER_PORTAL_REACT_DIR}:/app
       - /app/node_modules
     environment:
-      REACT_APP_REMS_OWNER_ID: ${REMS_OWNER_ID}
+      REACT_APP_REMS_API_KEY: ${REMS_API_KEY}
 
   db-katsu:
     image: postgres:latest

--- a/init/authorize.sh
+++ b/init/authorize.sh
@@ -78,7 +78,7 @@ while getopts ":hk:f:s:" opt; do
     h)  help
         exit
         ;;
-    k)  REMS_API_KEY="$OPTARG"
+    k)  export REMS_API_KEY="$OPTARG"
         ;;
     f)  composefile="$OPTARG"
         ;;
@@ -117,15 +117,15 @@ echo "composefile: " $composefile
 echo "service: " $service
 echo "REMS_API_KEY: " $REMS_API_KEY
 
-echo "Substituting the REMS API key into the docker-compose environment..."
-if _set_api_key
-then
-    echo "REMS API key added to the environment."
-fi
-echo
-
 case $service in
     rems)
+        echo "Substituting the REMS API key into the docker-compose environment..."
+        if _set_api_key
+        then
+            echo "REMS API key added to the environment."
+        fi
+        echo
+
         docker-compose -f $composefile exec $service sh -c \
         'java -Drems.config=/rems/config/config.edn -jar rems.jar api-key add '$REMS_API_KEY' Testing'
         echo 'Attempted to add api-key '$REMS_API_KEY

--- a/init/authorize.sh
+++ b/init/authorize.sh
@@ -10,6 +10,10 @@ help ()
    echo "FOR DEMO PURPOSES ONLY; DO NOT USE IN PRODUCTION."
    echo "Default behaviour is to assume that REMS is the target."
    echo
+   echo "Script dependencies: gnu_gettext (ie. gettext_base)"
+   echo 'Script can only inject the REMS_API_KEY into a .env file if .env contains the following line:'
+   echo '   REMS_API_KEY=${REMS_API_KEY}'
+   echo
    echo "Usage:"
    echo "   ./init/authorize.sh [options] USERID"
    echo "Arguments:"
@@ -27,20 +31,54 @@ help ()
 # Main program                                                                 #
 ################################################################################
 ################################################################################
+
+# Substitute ${VAR} reference to REMS API key in the .env file with its value.
+# Requires gnu_gettext's envsubst be installed: apt-get install gettext-base
+_set_api_key () {
+
+    case `grep '{REMS_API_KEY}' .env > /dev/null; echo $?` in
+        0)
+            # Found the reference in the .env file; can substitute the value in.
+            envsubst '${REMS_API_KEY}' < .env > tmp/.env
+            cat tmp/.env > .env
+            ;;
+        1)
+            # Did not find the reference in the .env file.
+            echo 'WARNING: .env file does not contain the ${REMS_API_KEY} reference!'
+            echo 'Unable to substitute the value of ${REMS_API_KEY} into the .env file.'
+            echo 'Please do so manually, or rerun this script after adding the reference to the .env file.'
+            echo 'ex. To reset the .env file to its default state, run the following command:'
+            echo 'cp .default.env .env'
+            return 1
+            ;;
+        *)
+            echo 'WARNING: error when checking for presence of ${REMS_API_KEY} reference in the .env file!'
+            echo 'Unable to substitute the value of ${REMS_API_KEY} into the .env file.'
+            echo 'Please do so manually, or rerun this script after adding the reference to the .env file.'
+            echo 'ex. To reset the .env file to its default state, run the following command:'
+            echo 'cp .default.env .env'
+            return 2
+            ;;
+    esac
+}
+
+
+################################# Script start
+
 # Default docker-compose filename.
 composefile="docker-compose.yaml"
 # Default service name to exec the migration in.
 service="rems"
 # Default api key to add, if applicable.
-apikey="abc123"
+export REMS_API_KEY="abc123"
 
-# Optionally overwrite docker compose filename, service to migrate, or apikey to add
+# Optionally overwrite docker compose filename, service to migrate, or REMS_API_KEY to add
 while getopts ":hk:f:s:" opt; do
   case $opt in
     h)  help
         exit
         ;;
-    k)  apikey="$OPTARG"
+    k)  REMS_API_KEY="$OPTARG"
         ;;
     f)  composefile="$OPTARG"
         ;;
@@ -54,15 +92,43 @@ shift $((OPTIND - 1))
 
 user="$1"
 
+# Error if dependency is missing
+if ! command -v envsubst &> /dev/null
+then
+    echo "envsubst could not be found"
+    echo "Please install gnu_gettext, ex.:"
+    echo "      apt-get install gettext-base"
+    exit 1
+fi
+
+# Create required local tmp file
+mkdir -p tmp
+if [[ ! -d tmp && -f tmp ]]; then
+    echo "ERROR: tmp folder in current host directory is a file instead of a directory."
+    echo "Please replace with tmp directory and rerun script"
+    exit 1
+elif [[ ! -d tmp ]]; then
+    echo "ERROR: no tmp folder in current host directory."
+    echo "Please create tmp directory and rerun script"
+    exit 1
+fi
+
 echo "composefile: " $composefile
 echo "service: " $service
-echo "apikey: " $apikey
+echo "REMS_API_KEY: " $REMS_API_KEY
+
+echo "Substituting the REMS API key into the docker-compose environment..."
+if _set_api_key
+then
+    echo "REMS API key added to the environment."
+fi
+echo
 
 case $service in
     rems)
         docker-compose -f $composefile exec $service sh -c \
-        'java -Drems.config=/rems/config/config.edn -jar rems.jar api-key add '$apikey' Testing'
-        echo 'Attempted to add api-key '$apikey
+        'java -Drems.config=/rems/config/config.edn -jar rems.jar api-key add '$REMS_API_KEY' Testing'
+        echo 'Attempted to add api-key '$REMS_API_KEY
 
         docker-compose -f $composefile exec $service sh -c \
         'java -Drems.config=/rems/config/config.edn -jar rems.jar grant-role owner '$user


### PR DESCRIPTION
## Changelog
- Removed environment variable `REMS_OWNER_ID` since it is no longer needed (see https://github.com/CSCfi/rems/issues/2631).
- Added environment variable `REMS_API_KEY`.
- Refactored `init/authorize.sh` to set the value of the REMS API key in the `.env` file.
- `REMS_API_KEY` is passed to the `rp-react` container as an environment variable.

## Dependencies
Mutually dependent on https://github.com/dycons/researcher-portal/pull/17